### PR TITLE
:sparkles: Reveal in Explorer when Explorer visible

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,30 +29,12 @@ export function activate(context: vscode.ExtensionContext) {
 			context.subscriptions.push(galleryFileWatcher);
 
 			mainPanel.webview.onDidReceiveMessage(
-				async message => {
-					switch (message.command) {
-						case 'vscodeImageGallery.openViewer':
-							const resource = vscode.Uri.file(vscode.Uri.parse(message.src).path);
-							await vscode.commands.executeCommand(
-								'vscode.open',
-								resource,
-								{
-									preserveFocus: true,
-									preview: message.preview,
-									viewColumn: vscode.ViewColumn.Two,
-								},
-							);
-							return;
-					}
-				},
+				gallery.getMessageListener(),
 				undefined,
-				context.subscriptions,
+				context.subscriptions
 			);
-
 			mainPanel.onDidDispose(
-				() => {
-					galleryFileWatcher.dispose();
-				},
+				() => galleryFileWatcher.dispose(),
 				undefined,
 				context.subscriptions
 			);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,7 +29,7 @@ export function activate(context: vscode.ExtensionContext) {
 			context.subscriptions.push(galleryFileWatcher);
 
 			mainPanel.webview.onDidReceiveMessage(
-				gallery.getMessageListener(),
+				(message) => gallery.getMessageListener(message),
 				undefined,
 				context.subscriptions
 			);

--- a/src/gallery.ts
+++ b/src/gallery.ts
@@ -21,7 +21,7 @@ export async function createPanel(context: vscode.ExtensionContext, galleryFolde
     return panel;
 }
 
-export async function getImagePaths(galleryFolder?: vscode.Uri) {
+async function getImagePaths(galleryFolder?: vscode.Uri) {
     const globPattern = utils.getGlob();
     const files = await vscode.workspace.findFiles(
         galleryFolder ? new vscode.RelativePattern(galleryFolder, globPattern) : globPattern
@@ -29,7 +29,7 @@ export async function getImagePaths(galleryFolder?: vscode.Uri) {
     return files;
 }
 
-export function sortPathsBySubFolders(pathsBySubFolders: { [key: string]: Array<vscode.Uri> }): { [key: string]: Array<vscode.Uri> } {
+function sortPathsBySubFolders(pathsBySubFolders: { [key: string]: Array<vscode.Uri> }): { [key: string]: Array<vscode.Uri> } {
     const config = vscode.workspace.getConfiguration('sorting.byPathOptions');
     const keys = [
         'localeMatcher',
@@ -59,7 +59,7 @@ export function sortPathsBySubFolders(pathsBySubFolders: { [key: string]: Array<
     return sortedResult;
 }
 
-export function getWebviewContent(
+function getWebviewContent(
     context: vscode.ExtensionContext,
     webview: vscode.Webview,
     pathsBySubFolders: { [key: string]: Array<vscode.Uri> },
@@ -105,4 +105,43 @@ export function getWebviewContent(
 		</body>
 		</html>`
     );
+}
+
+export function getMessageListener() {
+    return async (message: {
+        command: string,
+        src: string,
+        preview: boolean,
+    }) => {
+        switch (message.command) {
+            case 'vscodeImageGallery.openViewer':
+                openViewerOnClick(
+                    vscode.Uri.file(vscode.Uri.parse(message.src).path),
+                    message.preview,
+                );
+                break;
+        }
+    };
+}
+
+async function openViewerOnClick(resource: vscode.Uri, preview: boolean) {
+    await vscode.commands.executeCommand(
+        'vscode.open',
+        resource,
+        {
+            preserveFocus: true,
+            preview: preview,
+            viewColumn: vscode.ViewColumn.Two,
+        },
+    );
+
+    const explorerVisible = vscode.workspace.getConfiguration('explorer').get('visible');
+    if (explorerVisible) {
+        await vscode.commands.executeCommand(
+            'workbench.files.action.showActiveFileInExplorer',
+            resource,
+        );
+    }
+
+    return;
 }

--- a/src/gallery.ts
+++ b/src/gallery.ts
@@ -107,31 +107,18 @@ function getWebviewContent(
     );
 }
 
-export function getMessageListener() {
-    return (message: {
-        command: string,
-        src: string,
-        preview: boolean,
-    }) => {
-        switch (message.command) {
-            case 'vscodeImageGallery.openViewer':
-                openViewerOnClick(
-                    vscode.Uri.file(vscode.Uri.parse(message.src).path),
-                    message.preview,
-                );
-                break;
-        }
-    };
-}
-
-function openViewerOnClick(resource: vscode.Uri, preview: boolean) {
-    vscode.commands.executeCommand(
-        'vscode.open',
-        resource,
-        {
-            preserveFocus: false,
-            preview: preview,
-            viewColumn: vscode.ViewColumn.Two,
-        },
-    );
+export function getMessageListener(message: any) {
+    switch (message.command) {
+        case 'vscodeImageGallery.openViewer':
+            vscode.commands.executeCommand(
+                'vscode.open',
+                vscode.Uri.file(vscode.Uri.parse(message.src).path),
+                {
+                    preserveFocus: false,
+                    preview: message.preview,
+                    viewColumn: vscode.ViewColumn.Two,
+                },
+            );
+            break;
+    }
 }

--- a/src/gallery.ts
+++ b/src/gallery.ts
@@ -129,7 +129,7 @@ function openViewerOnClick(resource: vscode.Uri, preview: boolean) {
         'vscode.open',
         resource,
         {
-            preserveFocus: true,
+            preserveFocus: false,
             preview: preview,
             viewColumn: vscode.ViewColumn.Two,
         },

--- a/src/gallery.ts
+++ b/src/gallery.ts
@@ -134,14 +134,4 @@ async function openViewerOnClick(resource: vscode.Uri, preview: boolean) {
             viewColumn: vscode.ViewColumn.Two,
         },
     );
-
-    const explorerVisible = vscode.workspace.getConfiguration('explorer').get('visible');
-    if (explorerVisible) {
-        await vscode.commands.executeCommand(
-            'workbench.files.action.showActiveFileInExplorer',
-            resource,
-        );
-    }
-
-    return;
 }

--- a/src/gallery.ts
+++ b/src/gallery.ts
@@ -108,7 +108,7 @@ function getWebviewContent(
 }
 
 export function getMessageListener() {
-    return async (message: {
+    return (message: {
         command: string,
         src: string,
         preview: boolean,
@@ -124,8 +124,8 @@ export function getMessageListener() {
     };
 }
 
-async function openViewerOnClick(resource: vscode.Uri, preview: boolean) {
-    await vscode.commands.executeCommand(
+function openViewerOnClick(resource: vscode.Uri, preview: boolean) {
+    vscode.commands.executeCommand(
         'vscode.open',
         resource,
         {


### PR DESCRIPTION
Successful merge shall fix #68.

To manually test the feature:
1. Open Gallery, and make sure the Explorer side bar is visible.
2. Click on any image (both single and double clicks). This should reveal (select/highlight) the image on the Explorer side bar.
<img width="773" alt="image" src="https://user-images.githubusercontent.com/21100851/175753327-2bd58738-cc16-4cb1-975a-d08b91b095d0.png">

3. Close the Explorer (hide) or have the side bar display something else (select other icons on the Activity Bar).
4. Clicking on any image should **not** select anything in the Explorer.

![image](https://user-images.githubusercontent.com/21100851/175753419-fa929203-66fc-4dfe-a9d6-5dddacf382ad.png)
