### PR TITLE
Support TXT files as potential gallery targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [1.3.0] - 2024-03-10
+### Added
+- TXT files can now be right-clicked and opened like directories in file explorer.
+
 ## [1.2.1] - 2022-09-28
 ### Fixed
 - Supported file extensions are now consistent between [`package.json`](package.json) and [`src/utils.ts`](src/utils.ts).

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-image-gallery",
 	"displayName": "Image Gallery",
 	"description": "Improve image browsing experience, especially for remote development.",
-	"version": "1.2.1",
+	"version": "1.3.0",
 	"publisher": "GeriYoco",
 	"repository": {
 		"type": "git",
@@ -101,6 +101,11 @@
 					"command": "gryc.openGallery",
 					"group": "2_grycImageGallery@1",
 					"when": "explorerResourceIsFolder && !virtualWorkspace"
+				},
+				{
+					"command": "gryc.openGallery",
+					"group": "2_grycImageGallery@1",
+					"when": "resourceFilename =~ /.*\\.txt/"
 				}
 			]
 		}

--- a/src/gallery/script.js
+++ b/src/gallery/script.js
@@ -141,7 +141,7 @@ class DOMManager {
 			})
 		);
 		if (content.childElementCount === 0) {
-			content.innerHTML = "<p>No image found in this folder.</p>";
+			content.innerHTML = "<p>No image found in this gallery target.</p>";
 		}
 	}
 }


### PR DESCRIPTION
This is a feature we discussed a few days ago in an issue.


Right-clicking on a txt file in file explorer will show an option to open it as a gallery.

Such TXT files usually contain images outside of the working directory, therefore VSCode is given permission to access all files on the local system. <- This could be reduced to parent folders of all images.

BTW currently `vsce` fails to compile your extension because it contains SVGs.