### PR TITLE
Add automatic image refresh support to the Viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [1.2.2] - 2026-01-18
+### Added
+- Viewer: Images now auto-refresh when the file changes.
+
 ## [1.2.1] - 2022-09-28
 ### Fixed
 - Supported file extensions are now consistent between [`package.json`](package.json) and [`src/utils.ts`](src/utils.ts).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-image-gallery",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-image-gallery",
-			"version": "1.2.1",
+			"version": "1.2.2",
 			"dependencies": {
 				"@vscode/extension-telemetry": "^0.6.2",
 				"panzoom": "^9.4.2"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-image-gallery",
 	"displayName": "Image Gallery",
 	"description": "Improve image browsing experience, especially for remote development.",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"publisher": "GeriYoco",
 	"repository": {
 		"type": "git",

--- a/src/viewer/script.js
+++ b/src/viewer/script.js
@@ -5,3 +5,13 @@
 		minZoom: 0.6,
 	});
 }());
+
+const image = document.getElementById('image');
+window.addEventListener('message', (event) => {
+	const message = event.data;
+	if (message && message.type === 'refreshImage' && image) {
+		const src = image.src.split('?')[0];
+		image.src = src + '?t=' + Date.now();
+		console.log('Image refreshed since updated externally:', src);
+	}
+});

--- a/src/viewer/viewer.ts
+++ b/src/viewer/viewer.ts
@@ -46,6 +46,20 @@ export class ViewerWebview implements vscode.CustomReadonlyEditorProvider {
 			enableForms: false
 		};
 		webviewPanel.webview.html = getWebviewContent(this.context, webviewPanel.webview, documentPath);
+
+		const watcher = vscode.workspace.createFileSystemWatcher(document.uri.fsPath);
+		watcher.onDidChange(() => {
+			webviewPanel.webview.postMessage({ type: 'refreshImage' });
+		});
+		watcher.onDidCreate(() => {
+			webviewPanel.webview.postMessage({ type: 'refreshImage' });
+		});
+		watcher.onDidDelete(() => {
+			webviewPanel.webview.postMessage({ type: 'refreshImage' });
+		});
+		webviewPanel.onDidDispose(() => {
+			watcher.dispose();
+		});
 	}
 }
 


### PR DESCRIPTION
Hi, if you frequently update images externally, the Viewer now automatically detects file changes and refreshes the image, allowing you to see updates immediately without losing zoom or pan state.

Steps:

- Open an image in the Viewer, for example an SVG file.
- Update that SVG file elsewhere or in a separate VS Code tab.
- See the update automatically reflected without breaking the zoom or pan level.